### PR TITLE
april 2019 meetup at wunderdog init

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 Clojure Finland home and agenda
 
 # Meetups
-- Call for papers open until (tba)! April (date tba) @ Wunderdog, Mikonkatu 13, Helsinki
+- Monday April 29 17.30 @ Wunderdog, Mikonkatu 13, Helsinki

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # home
 Clojure Finland home and agenda
+
+# Meetups
+- Call for papers open until (tba)! April (date tba) @ Wunderdog, Mikonkatu 13, Helsinki


### PR DESCRIPTION
Wunderdog signs up for April as agreed.

Call for papers is now open. Spread the word, time is nigh.